### PR TITLE
Ensure main Component Manager is set

### DIFF
--- a/src/setup-rendering-test.ts
+++ b/src/setup-rendering-test.ts
@@ -58,6 +58,12 @@ function render(
         `component-manager:/${app.rootName}/component-managers/test-container`,
         CustomComponentManager
       );
+
+      /*
+       * Register the main ComponentManager for everything else to use as their
+       * default
+       */
+      registry.register(`component-manager:/${app.rootName}/component-managers/main`, ComponentManager);
     }
   });
 


### PR DESCRIPTION
In a previous PR we registered our wrapping test container component and it's
associated component manager to allow context sharing between the test context
and the wrapping component.  When we did this we removed the default Component
Manager registration.  This wasn't necessary in our testing because we did not
invoke another component in our simple example.   Components rendered inside
the inline compile need to have the default component manager registered as
before